### PR TITLE
docs: use correct env._ directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Install this plugin, then add this to your `mise.toml`:
 
 ```toml
 [env]
-_.mise-env-sample = { path_to_add = "/sample/path" }
+_.env-sample = { path_to_add = "/sample/path" }
 ```
 
 You'll now see this added to your environment when running `mise env`.


### PR DESCRIPTION
seems like at some point this changed?